### PR TITLE
Potential fix for code scanning alert no. 16: Missing rate limiting

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -35,7 +35,8 @@
     "express-session": "^1.17.3",
     "mongodb": "^4.9.1",
     "morgan": "~1.10.0",
-    "redis": "^4.3.1"
+    "redis": "^4.3.1",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "eslint": "^8.23.1",


### PR DESCRIPTION
Potential fix for [https://github.com/eduappsec1/nodejs-demoapp/security/code-scanning/16](https://github.com/eduappsec1/nodejs-demoapp/security/code-scanning/16)

The best way to address the issue is by introducing a rate-limiting middleware to the Express application. We will use the popular `express-rate-limit` package to restrict the number of requests to the route within a specified time window. 

Specifically:
1. Install the `express-rate-limit` package.
2. Import and configure the rate limiter in `src/todo/routes.mjs`.
3. Apply the rate limiter to the `/api/todo/:id` route (or all `/api/todo` routes, if appropriate).

The rate limiter will limit the number of requests from a single IP to a reasonable threshold, mitigating the risk of DoS attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
